### PR TITLE
Made BIN optional during browserpass inreplace

### DIFF
--- a/Formula/browserpass.rb
+++ b/Formula/browserpass.rb
@@ -1,8 +1,14 @@
 class Browserpass < Formula
   desc "Host application for browser extension providing access to your password store"
   homepage "https://github.com/browserpass/browserpass-native"
-  url "https://github.com/browserpass/browserpass-native/releases/download/3.0.7/browserpass-darwin64-3.0.7.tar.gz"
-  sha256 "97b9a9068a3c88fb1d52d42a1712e199da5865a4c6f8352b9fe3eae1ee86c746"
+
+  if Hardware::CPU.arm?
+    url "https://github.com/browserpass/browserpass-native/releases/download/3.0.8/browserpass-darwin-arm64-3.0.8.tar.gz"
+    sha256 "f0a21c7610fb9c68a2f1b8aa8c4116678a2318e61b0b60067d79b5b23bcd4502"
+  else
+    url "https://github.com/browserpass/browserpass-native/releases/download/3.0.8/browserpass-darwin64-3.0.8.tar.gz"
+    sha256 "a4bd59a0d2fe74dfb16cca8d47011415eaa19d5da39a8c60ac948a491cfa7214"
+  end
 
   bottle do
     root_url "https://github.com/Amar1729/homebrew-formulae/releases/download/browserpass-3.0.7"
@@ -25,7 +31,11 @@ class Browserpass < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
 
-    inreplace "Makefile", "BIN ?= browserpass", "BIN ?= browserpass-darwin64"
+    if Hardware::CPU.arm?
+      inreplace "Makefile", "BIN ?= browserpass", "BIN ?= browserpass-darwin-arm64"
+    else
+      inreplace "Makefile", "BIN ?= browserpass", "BIN ?= browserpass-darwin64"
+    end
     system "make", "configure"
     system "make", "install"
 
@@ -50,6 +60,10 @@ class Browserpass < Formula
     resource("testfile").stage(testpath)
     # fails with 14: $HOME/.password-store doesn't exist, since homebrew uses its own $HOME
     # a return value other than 14 is incorrect here
-    shell_output("#{prefix}/bin/browserpass-darwin64 < #{testpath}/request.hex.txt 2>/dev/null", 14)
+    if Hardware::CPU.arm?
+      shell_output("#{prefix}/bin/browserpass-darwin-arm64 < #{testpath}/request.hex.txt 2>/dev/null", 14)
+    else
+      shell_output("#{prefix}/bin/browserpass-darwin64 < #{testpath}/request.hex.txt 2>/dev/null", 14)
+    end
   end
 end

--- a/Formula/browserpass.rb
+++ b/Formula/browserpass.rb
@@ -25,7 +25,7 @@ class Browserpass < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
 
-    inreplace "Makefile", "BIN = browserpass", "BIN = browserpass-darwin64"
+    inreplace "Makefile", "BIN ?= browserpass", "BIN ?= browserpass-darwin64"
     system "make", "configure"
     system "make", "install"
 


### PR DESCRIPTION
The makefile in browserpass-native (https://github.com/browserpass/browserpass-native/blob/master/Makefile) has been updated to have the `BIN` optional. This requires either the inreplace to be updated to reflect this change, or the env variable to be added before running make.

This PR reflects the in-file change and does **not** cover adding the environment variable.